### PR TITLE
fix: bad regexp escape for custom diff colors

### DIFF
--- a/github-dark-diff-color-customizer.user.css
+++ b/github-dark-diff-color-customizer.user.css
@@ -20,7 +20,7 @@
 
 @preprocessor stylus
 ==/UserStyle== */
-@-moz-document regexp("^https?://((gist|guides|help|lab|launch-editor|raw|resources|status|developer)\.)?github\.com/((?!generated_pages/preview)\.)*$") {
+@-moz-document regexp("^https?://((education|gist|graphql|guides|help|raw|resources|status|developer|support|vscode-auth)\\.)?github\\.com/((?!generated_pages/preview).)*$") {
   /*** Based on https://userstyles.org/styles/149864/github-diff-colorblind-friendly ***
   .blob-num sets the colors in the number columns on the left
   .blob-code sets the color of the rest of the line


### PR DESCRIPTION
Heya,

Removing escape from `.` seems to resolve #1. I also had a look at GHD and updated the regexp so that they match.